### PR TITLE
wait until page is completely loaded

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ app.get('/', async (req, res) => {
             // const browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']})
             const browser = await puppeteer.launch()
             const page = await browser.newPage()
-            await page.goto(`https://${url}`)
+            await page.goto(`https://${url}`, {"waitUntil" : ['load', 'domcontentloaded', 'networkidle0']})
             
             let document = await page.evaluate(() => document.documentElement.outerHTML)
             document = replace(document, `/?url=${url.split('/')[0]}`)


### PR DESCRIPTION
# wait until page is completely loaded

await page.goto(url, { waitUntil: 'load' });
await page.goto(url, { waitUntil: 'domcontentloaded' });
await page.goto(url, { waitUntil: 'networkidle0' });
await page.goto(url, { waitUntil: 'networkidle2' });

await page.goto(url);
await page.waitForFunction("renderingCompleted === true")


# ٌReferances
https://github.com/puppeteer/puppeteer/blob/v1.0.0/docs/api.md#pagegotourl-options
https://github.com/puppeteer/puppeteer/issues/1875#issuecomment-359448297
https://stackoverflow.com/questions/52497252/puppeteer-wait-until-page-is-completely-loaded